### PR TITLE
Extract plotting helpers into dedicated module

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,9 @@ at the link below.
 
 ### Plotting functions
 
+The plotting utilities are defined in `dRFEtools.plotting` and are also
+re-exported from the top-level `dRFEtools` package for backward compatibility.
+
 1.  Save plots
 
     `save_plots`

--- a/dRFEtools/__init__.py
+++ b/dRFEtools/__init__.py
@@ -16,8 +16,8 @@ from ._lowess_redundant import (
 
 from .dRFEtools import (
     rf_rfe, dev_rfe,
-    plot_metric, plot_with_lowess_vline
 )
+from .plotting import plot_metric, plot_with_lowess_vline
 
 __version__ = "0.3.5"
 

--- a/dRFEtools/dRFEtools.py
+++ b/dRFEtools/dRFEtools.py
@@ -28,24 +28,9 @@ Feature ranking modified from Tarun Katipalli (TK) ranking function.
 """
 __author__ = 'Apuã Paquola'
 
-import numpy as np
-import pandas as pd
-from plotnine import *
-from warnings import filterwarnings
-from matplotlib import MatplotlibDeprecationWarning
-
 from ._dev_scoring import _regr_fe
 from ._random_forest import _rf_fe
-from ._lowess_redundant import (
-    _cal_lowess,
-    extract_max_lowess,
-    optimize_lowess_plot,
-    extract_peripheral_lowess
-)
-
-filterwarnings("ignore", category=MatplotlibDeprecationWarning)
-filterwarnings('ignore', category=UserWarning, module='plotnine.*')
-filterwarnings('ignore', category=DeprecationWarning, module='plotnine.*')
+from .plotting import plot_metric, plot_with_lowess_vline
 
 __all__ = [
     "rf_rfe",
@@ -139,95 +124,3 @@ def dev_rfe(estimator, X, Y, features, fold, out_dir='.', elimination_rate=0.2,
         d[p[0]] = p
 
     return d, pfirst
-
-
-def _save_plot(p, fn, width=7, height=7):
-    '''
-    Save plot as svg, png, and pdf with specific label and dimension.
-
-    Args:
-        p: Plot object
-        fn (str): File name (without extension)
-        width (int): Plot width. Default 7
-        height (int): Plot height. Default 7
-    '''
-    for ext in ['.svg', '.png', '.pdf']:
-        p.save(fn + ext, width=width, height=height)
-
-
-def plot_metric(d, fold, output_dir, metric_name, y_label):
-    """
-    Plot feature elimination results for normalized mutual information.
-
-    Args:
-        d (dict): Feature elimination class dictionary
-        fold (int): Current fold
-        output_dir (str): Output directory
-        metric_name (str): Name of the metric (used for file naming)
-        y_label (str): Label for y-axis
-
-    Returns:
-        None: Saves plot files and prints the plot
-    """
-    if metric_name in ["nmi", "r2"]:
-        key_num = 1
-    elif metric_name in ["roc", "mse"]:
-        key_num = 2
-    elif metric_name in ["acc", "evar"]:
-        key_num = 3
-    else:
-        raise ValueError(f"Unknown metric_name: {metric_name}")
-    df_elim = pd.DataFrame([{'n features': k,
-                             y_label: d[k][key_num]} for k in d.keys()])
-
-    gg = (ggplot(df_elim, aes(x='n features', y=y_label))
-          + geom_point()
-          + scale_x_log10()
-          + theme_light()
-          + labs(x="Number of features", y=y_label))
-
-    outfile = f"{output_dir}/{metric_name}_fold_{fold}"
-    _save_plot(gg, outfile)
-    print(gg)
-
-
-def plot_with_lowess_vline(d, fold, output_dir, frac=3/10, step_size=0.05,
-                           classify=True, multi=False, acc=False):
-    """
-    Plot the LOWESS smoothing plot for RFE with lines annotating set selection.
-
-    Args:
-        d (dict): Feature elimination class dictionary
-        fold (int): Current fold
-        output_dir (str): Output directory
-        frac (float): Fraction for LOWESS smoothing. Default 3/10
-        step_size (float): Step size for peripheral feature extraction. Default 0.05
-        classify (bool): Whether it's a classification task. Default True
-        multi (bool): Whether it's a multi-class classification. Default False
-        acc (bool): Whether to use accuracy for optimization. Default False
-
-    Returns:
-        None: Saves plot files and prints the plot
-    """
-    if classify:
-        label = 'ROC AUC' if multi else 'Accuracy' if acc else 'NMI'
-    else:
-        label = 'R2'
-
-    _, max_feat_log10 = extract_max_lowess(d, frac, multi, acc)
-    x, y, z, _, _ = _cal_lowess(d, frac, multi, acc)
-    df_elim = pd.DataFrame({'X': x, 'Y': y})
-    _, lo = extract_max_lowess(d, frac, multi, acc)
-    _, l1 = extract_peripheral_lowess(d, frac, step_size, multi, acc)
-
-    gg = (ggplot(df_elim, aes(x='X', y='Y'))
-          + geom_point(color='blue')
-          + geom_vline(xintercept=lo, color='blue', linetype='dashed')
-          + geom_vline(xintercept=l1, color='orange', linetype='dashed')
-          + scale_x_log10()
-          + labs(x='log10(N Features)', y=label)
-          + theme_light())
-
-    print(gg)
-    outfile = f"{output_dir}/{label.replace(' ', '_')}_log10_dRFE_fold_{fold}"
-    _save_plot(gg, outfile)

--- a/dRFEtools/plotting.py
+++ b/dRFEtools/plotting.py
@@ -1,0 +1,111 @@
+"""Plotting utilities for dRFEtools."""
+
+import pandas as pd
+from plotnine import *
+from warnings import filterwarnings
+from matplotlib import MatplotlibDeprecationWarning
+
+from ._lowess_redundant import (
+    _cal_lowess,
+    extract_max_lowess,
+    optimize_lowess_plot,
+    extract_peripheral_lowess,
+)
+
+filterwarnings("ignore", category=MatplotlibDeprecationWarning)
+filterwarnings('ignore', category=UserWarning, module='plotnine.*')
+filterwarnings('ignore', category=DeprecationWarning, module='plotnine.*')
+
+__all__ = ["plot_metric", "plot_with_lowess_vline"]
+
+
+def _save_plot(p, fn, width=7, height=7):
+    """
+    Save plot as svg, png, and pdf with specific label and dimension.
+
+    Args:
+        p: Plot object
+        fn (str): File name (without extension)
+        width (int): Plot width. Default 7
+        height (int): Plot height. Default 7
+    """
+    for ext in ['.svg', '.png', '.pdf']:
+        p.save(fn + ext, width=width, height=height)
+
+
+def plot_metric(d, fold, output_dir, metric_name, y_label):
+    """
+    Plot feature elimination results for normalized mutual information.
+
+    Args:
+        d (dict): Feature elimination class dictionary
+        fold (int): Current fold
+        output_dir (str): Output directory
+        metric_name (str): Name of the metric (used for file naming)
+        y_label (str): Label for y-axis
+
+    Returns:
+        None: Saves plot files and prints the plot
+    """
+    if metric_name in ["nmi", "r2"]:
+        key_num = 1
+    elif metric_name in ["roc", "mse"]:
+        key_num = 2
+    elif metric_name in ["acc", "evar"]:
+        key_num = 3
+    else:
+        raise ValueError(f"Unknown metric_name: {metric_name}")
+    df_elim = pd.DataFrame([{'n features': k,
+                             y_label: d[k][key_num]} for k in d.keys()])
+
+    gg = (ggplot(df_elim, aes(x='n features', y=y_label))
+          + geom_point()
+          + scale_x_log10()
+          + theme_light()
+          + labs(x="Number of features", y=y_label))
+
+    outfile = f"{output_dir}/{metric_name}_fold_{fold}"
+    _save_plot(gg, outfile)
+    print(gg)
+
+
+def plot_with_lowess_vline(d, fold, output_dir, frac=3/10, step_size=0.05,
+                           classify=True, multi=False, acc=False):
+    """
+    Plot the LOWESS smoothing plot for RFE with lines annotating set selection.
+
+    Args:
+        d (dict): Feature elimination class dictionary
+        fold (int): Current fold
+        output_dir (str): Output directory
+        frac (float): Fraction for LOWESS smoothing. Default 3/10
+        step_size (float): Step size for peripheral feature extraction. Default 0.05
+        classify (bool): Whether it's a classification task. Default True
+        multi (bool): Whether it's a multi-class classification. Default False
+        acc (bool): Whether to use accuracy for optimization. Default False
+
+    Returns:
+        None: Saves plot files and prints the plot
+    """
+    if classify:
+        label = 'ROC AUC' if multi else 'Accuracy' if acc else 'NMI'
+    else:
+        label = 'R2'
+
+    _, max_feat_log10 = extract_max_lowess(d, frac, multi, acc)
+    x, y, z, _, _ = _cal_lowess(d, frac, multi, acc)
+    df_elim = pd.DataFrame({'X': x, 'Y': y})
+    _, lo = extract_max_lowess(d, frac, multi, acc)
+    _, l1 = extract_peripheral_lowess(d, frac, step_size, multi, acc)
+
+    gg = (ggplot(df_elim, aes(x='X', y='Y'))
+          + geom_point(color='blue')
+          + geom_vline(xintercept=lo, color='blue', linetype='dashed')
+          + geom_vline(xintercept=l1, color='orange', linetype='dashed')
+          + scale_x_log10()
+          + labs(x='log10(N Features)', y=label)
+          + theme_light())
+
+    print(gg)
+    outfile = f"{output_dir}/{label.replace(' ', '_')}_log10_dRFE_fold_{fold}"
+    _save_plot(gg, outfile)

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -20,6 +20,9 @@ Main functions
 Plotting functions
 ------------------
 
+Plotting helpers live in :mod:`dRFEtools.plotting` and are re-exported from the
+top-level package for convenience.
+
 .. autosummary::
    :toctree: functions
 


### PR DESCRIPTION
## Summary
- move plotting helper functions into a dedicated dRFEtools.plotting module
- keep backwards compatibility through package exports and update documentation to note the new location

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b117ab80c83238c8411976751a383)