### PR TITLE
Limit plotnine imports to used primitives

### DIFF
--- a/dRFEtools/dRFEtools.py
+++ b/dRFEtools/dRFEtools.py
@@ -30,7 +30,15 @@ __author__ = 'Apuã Paquola'
 
 import numpy as np
 import pandas as pd
-from plotnine import *
+from plotnine import (
+    aes,
+    ggplot,
+    geom_point,
+    geom_vline,
+    labs,
+    scale_x_log10,
+    theme_light,
+)
 from warnings import filterwarnings
 from matplotlib import MatplotlibDeprecationWarning
 


### PR DESCRIPTION
## Summary
- replace wildcard plotnine import with explicit primitives used by plotting helpers
- keep public API unchanged while reducing imported symbols

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b117d6e34832391a0016f41021916)