### PR TITLE
Add coverage-focused tests

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,8 @@
-from dRFEtools.dRFEtools import _n_features_iter
+from sklearn.ensemble import RandomForestClassifier
+from sklearn.linear_model import LinearRegression
+from sklearn.svm import SVC
+
+from dRFEtools.dRFEtools import _normalize_metrics, _n_features_iter
 
 
 def test_n_features_iter_respects_keep_rate():
@@ -6,3 +10,27 @@ def test_n_features_iter_respects_keep_rate():
     assert sequence[-1] == 1
     assert sequence[0] == 5
     assert all(n > 0 for n in sequence)
+
+
+def test_normalize_metrics_classifier_subset():
+    metrics = {"nmi_score": 0.1, "accuracy_score": 0.2, "roc_auc_score": 0.3, "r2_score": 0.4}
+    normalized = {"metrics": metrics}
+
+    clf_metrics = _normalize_metrics(SVC(), normalized)
+    assert clf_metrics == {"nmi_score": 0.1, "accuracy_score": 0.2, "roc_auc_score": 0.3}
+
+
+def test_normalize_metrics_random_forest_classifier_uses_same_subset():
+    metrics = {"nmi_score": 0.5, "accuracy_score": 0.6, "roc_auc_score": 0.7, "mse_score": 0.8}
+    normalized = {"metrics": metrics}
+
+    rf_metrics = _normalize_metrics(RandomForestClassifier(), normalized)
+    assert rf_metrics == {"nmi_score": 0.5, "accuracy_score": 0.6, "roc_auc_score": 0.7}
+
+
+def test_normalize_metrics_regressor_subset():
+    metrics = {"r2_score": 0.9, "mse_score": 1.0, "explain_var": 1.1, "accuracy_score": 0.2}
+    normalized = {"metrics": metrics}
+
+    reg_metrics = _normalize_metrics(LinearRegression(), normalized)
+    assert reg_metrics == {"r2_score": 0.9, "mse_score": 1.0, "explain_var": 1.1}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2,7 +2,16 @@ import pytest
 import numpy as np
 from sklearn.linear_model import LinearRegression
 
-from dRFEtools.utils import get_feature_importances, normalize_rfe_result
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+
+from dRFEtools.utils import (
+    ensure_path,
+    get_feature_importances,
+    normalize_rfe_result,
+    save_plot_variants,
+)
 
 
 def test_normalize_rfe_result_tuple_conversion():
@@ -21,6 +30,16 @@ def test_normalize_rfe_result_tuple_conversion():
     assert isinstance(result["indices"], np.ndarray) is False
 
 
+def test_normalize_rfe_result_dict_passthrough():
+    payload = {"n_features": 3, "metrics": {"nmi_score": 0.1}}
+    assert normalize_rfe_result(payload) == payload
+
+
+def test_normalize_rfe_result_invalid_type():
+    with pytest.raises(TypeError):
+        normalize_rfe_result("not-a-result")
+
+
 def test_get_feature_importances_linear_regression():
     X = np.array([[0.0, 1.0], [1.0, 2.0], [2.0, 3.0]])
     y = np.array([1.0, 2.0, 3.0])
@@ -28,3 +47,43 @@ def test_get_feature_importances_linear_regression():
     importances = get_feature_importances(model)
     assert importances.shape == (2,)
     assert np.all(importances >= 0)
+
+
+def test_get_feature_importances_multidimensional_coef():
+    class DummyEstimator:
+        def __init__(self):
+            self.coef_ = np.array([[1.0, -1.0, 0.5], [2.0, 0.0, 0.0]])
+
+    norms = get_feature_importances(DummyEstimator())
+    assert np.allclose(norms, np.array([3.0, 1.0, 0.5]))
+
+
+def test_get_feature_importances_feature_importances_attribute():
+    class FeatureImportanceEstimator:
+        def __init__(self):
+            self.feature_importances_ = np.array([0.1, 0.2, 0.3])
+
+    importances = get_feature_importances(FeatureImportanceEstimator())
+    assert importances.tolist() == [0.1, 0.2, 0.3]
+
+
+def test_save_plot_variants_matplotlib(tmp_path):
+    fig, ax = plt.subplots()
+    ax.plot([0, 1], [0, 1])
+
+    output_base = tmp_path / "plot"
+    save_plot_variants(fig, output_base)
+
+    for ext in (".svg", ".png", ".pdf"):
+        assert (output_base.with_suffix(ext)).exists()
+
+
+def test_ensure_path_resolves_user_and_relative(tmp_path, monkeypatch):
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+
+    relative = home / "sub" / ".." / "file.txt"
+    resolved = ensure_path(str(relative))
+    assert resolved == (home / "file.txt").resolve()
+    assert isinstance(resolved, Path)


### PR DESCRIPTION
## Summary
- add additional unit tests covering normalize_rfe_result edge cases and feature importance extraction paths
- exercise plot saving and path normalization helpers
- verify metric selection logic for classifier and regressor estimators

## Testing
- pytest -q *(fails: environment missing numpy/scikit-learn dependencies and cannot install via network-restricted environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692b309da9ec8323ab92f789b324efc2)